### PR TITLE
Skip dryrun on missing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Argo CD sync option to skip missing CRDs ([#3])
+
 ### Changed
 
 - Open source component ([#1])
@@ -14,5 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable Kapitan plugin ([#2])
 
 [Unreleased]: https://github.com/projectsyn/component-resource-locker/compare/eaf40fa...HEAD
+
 [#1]: https://github.com/projectsyn/component-resource-locker/pull/1
 [#2]: https://github.com/projectsyn/component-resource-locker/pull/2
+[#3]: https://github.com/projectsyn/component-resource-locker/pull/3

--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -14,6 +14,9 @@ local resourcelocker(name, sa) =
   kube._Object('redhatcop.redhat.io/v1alpha1', 'ResourceLocker', name) {
     metadata+: {
       namespace: namespace,
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
     },
     spec: {
       serviceAccountRef: {


### PR DESCRIPTION
If the CRD was not applied yet, the sync fails otherwise. See [1] for
further details.

[1] https://argoproj.github.io/argo-cd/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
