### PR TITLE
Allow patching objects with colons in the name

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -72,9 +72,13 @@ local clusterRoleName(name) =
   local start = nameLength - std.min(maxLength, std.length(name));
   prefix + std.substr(name, start, nameLength) + suffix;
 
+local replaceColon(str) =
+  std.strReplace(str, ':', '-');
+
 local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   local dest_ns = objdata.namespace;
-  local name = objdata.name;
+  // Some objects like ClusterRoleBinding can contain colons.
+  local name = replaceColon(objdata.name);
   // Create sa if not provided
   local saname = name + '-manager';
   local serviceaccount = kube.ServiceAccount(saname) {
@@ -137,10 +141,12 @@ local obj_data(obj) =
   };
 
 local rl_obj_name(objdata) =
+  // Some objects like ClusterRoleBinding can contain colons.
+  local name = replaceColon(objdata.name);
   if objdata.namespace != null then
-    '%(namespace)s-%(name)s' % objdata
+    '%s-%s' % [ objdata.namespace, name ]
   else
-    objdata.name;
+    name;
 
 /**
  * \brief Create a managed resource (similar to Espejo, but for single NS)


### PR DESCRIPTION
This PR allows patching objects, such as `ClusterRoleBinding`s, with colons in them.

The `ResourceLocker` and `ServiceAccount` object names can't contain colons.
The colon (`:`) is replaced by a hyphen (`-`) for the generated RBAC and `ResourceLocker` object names.