### PR TITLE
Make component library version-aware

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -14,6 +14,24 @@ local inv = kap.inventory();
 local resource_locker_params = inv.parameters.resource_locker;
 local namespace = resource_locker_params.namespace;
 
+local resource_locker_version =
+  if std.objectHas(resource_locker_params, 'charts') then
+    resource_locker_params.images['resource-locker-operator'];
+
+// Inject `id` for patches for resource-locker v1.x
+// Defaults to v1.x logic when image version cannot be determined from
+// parameters.
+local render_patch(patch) =
+  if (
+    resource_locker_version != null &&
+    std.startsWith(resource_locker_version, 'v0')
+  ) then
+    patch
+  else
+    patch {
+      id: 'patch1',
+    };
+
 /**
  * \brief The apiVersion to use when creating `ResourceLocker` objects without
  *        using the helper functions in this library.
@@ -55,12 +73,13 @@ local resource(name, sa, obj) =
 local patch(name, sa, targetobjref, patchtemplate, patchtype='application/strategic-merge-patch+json') =
   resourcelocker(name, sa) {
     spec+: {
-      patches: [ {
-        id: 'patch1',
-        targetObjectRef: targetobjref,
-        patchTemplate: std.manifestYamlDoc(patchtemplate),
-        patchType: patchtype,
-      } ],
+      patches: [ render_patch(
+        {
+          targetObjectRef: targetobjref,
+          patchTemplate: std.manifestYamlDoc(patchtemplate),
+          patchType: patchtype,
+        }
+      ) ],
     },
   };
 


### PR DESCRIPTION
This commit introduces logic in the component library to generate resource-locker patches which match the deployed resource-locker CRD version.

Currently, the library only has logic to ensure we only inject the field `id` for each patch when resource-locker-operator v1.x is deployed by the component.

Note: if the user configures a chart version v1.x and a image v0.x things are likely to still break.

Fixes #9

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
