### PR TITLE
Fix misgenerated resource names for cluster role in component library

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -107,7 +107,9 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   };
   // Create cluster role to get/list/watch resource kind
   local rolename = clusterRoleName(name);
-  local resource = std.asciiLower(objdata.kind) + 's';
+  local res = std.asciiLower(objdata.kind);
+  local suffix = if std.endsWith(res, 's') then 'es' else 's';
+  local resource = res + suffix;
   local clusterrole_extra_verbs = if dest_ns == null then verbs else [];
   local clusterrole = kube.ClusterRole(rolename) {
     rules+: [ {


### PR DESCRIPTION
Previously, the component library did not correctly generate resource names for the cluster role rules if the singular resource name ends with an `s`.

This PR introduces additional logic to generate suffix `es` when pluralizing resource names whose singular ends in `s`.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Rebase after #17 is merged

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
