### PR TITLE
Expose `renderPatch()` in component library

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -21,10 +21,10 @@ local resource_locker_version =
 // Inject `id` for patches for resource-locker v1.x
 // Defaults to v1.x logic when image version cannot be determined from
 // parameters.
-local render_patch(patch) =
+local render_patch(patch, rl_version) =
   if (
-    resource_locker_version != null &&
-    std.startsWith(resource_locker_version, 'v0')
+    rl_version != null &&
+    std.startsWith(rl_version, 'v0')
   ) then
     patch
   else
@@ -78,7 +78,8 @@ local patch(name, sa, targetobjref, patchtemplate, patchtype='application/strate
           targetObjectRef: targetobjref,
           patchTemplate: std.manifestYamlDoc(patchtemplate),
           patchType: patchtype,
-        }
+        },
+        resource_locker_version
       ) ],
     },
   };
@@ -214,4 +215,5 @@ local Patch(targetobj, patchtemplate, patchstrategy='application/strategic-merge
   apiVersion: apiVersion,
   Resource: Resource,
   Patch: Patch,
+  renderPatch: render_patch,
 }


### PR DESCRIPTION
This allows users to ensure their resource-locker patches are formatted correctly for the provided resource-locker version. Currently, users must provide the target version themselves.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
