### PR TITLE
Add prefix to generated names for cluster-scoped configurations

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -98,23 +98,29 @@ local replaceColon(str) =
 local rl_obj_name(objdata) =
   // Some objects like ClusterRoleBinding can contain colons.
   local name = replaceColon(objdata.name);
-  if objdata.namespace != null then
-    '%s-%s' % [ objdata.namespace, name ]
-  else
-    // Reduce potential for name collisions when generating names for
-    // cluster-scoped ResourceLocker configurations.
-    local prefix =
-      if objdata.apigroup != '' then
-        '%s-%s' % [
-          std.asciiLower(objdata.kind),
-          std.strReplace(objdata.apigroup, '.', '-'),
-        ]
+  local n =
+    if objdata.namespace != null then
+      '%s-%s' % [ objdata.namespace, name ]
+    else
+      // Reduce potential for name collisions when generating names for
+      // cluster-scoped ResourceLocker configurations.
+      local prefix =
+        if objdata.apigroup != '' &&
+           std.length(objdata.apigroup + objdata.kind + name) <= 61
+        then
+          '%s-%s' % [
+            std.asciiLower(objdata.kind),
+            std.strReplace(objdata.apigroup, '.', '-'),
+          ]
+        else
+          std.asciiLower(objdata.kind);
+      if std.length(prefix + name) >= 63 then
+        name
       else
-        std.asciiLower(objdata.kind);
-    '%s-%s' % [
-      prefix,
-      name,
-    ];
+        '%s-%s' % [ prefix, name ];
+
+  assert std.length(n) <= 63;
+  n;
 
 local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   local dest_ns = objdata.namespace;


### PR DESCRIPTION
Previously, resource names generated by the component library for cluster-scoped configurations only used the target object name. This can easily lead to name collisions. For example, OpenShift 4 has many CRs named `cluster`.

This commit  adds code to use the target object kind and API group as a prefix when generating names for cluster-scoped configurations to reduce the potential for collisions. If the fully prefixed name `<kind>-<apigroup>-<resourcename>` results in more than 64 characters, the code drops the apigroup section, and uses `<kind>-<resourcename>` instead to find a balance between avoiding collisions and staying below the 64 character length limit for Kubernetes resource names.

If all prefixing results in names that are longer than 64 characters,
fall back to just using the target resource name.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
