### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/resource-locker.yml
+++ b/class/resource-locker.yml
@@ -22,7 +22,7 @@ parameters:
           - resource-locker/helmcharts/resource-locker-operator-${resource_locker:charts:resource-locker-operator}
         helm_values: ${resource_locker:helmValues}
         helm_params:
-          release_name: resource-locker-operator
+          name: resource-locker-operator
           namespace: ${resource_locker:namespace}
   commodore:
     postprocess:


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
