### PR TITLE
Change registry for `bitnami/kubectl` to docker.io

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,7 +10,7 @@ parameters:
         tag: v1.1.0
         pullPolicy: IfNotPresent
       kubectl:
-        registry: quay.io
+        registry: docker.io
         repository: bitnami/kubectl
         tag: 1.21.5
     helmValues:

--- a/tests/golden/defaults/resource-locker/resource-locker/10_upgrade_job.yaml
+++ b/tests/golden/defaults/resource-locker/resource-locker/10_upgrade_job.yaml
@@ -86,7 +86,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: NEW_VERSION
               value: v1.1.0
-          image: quay.io/bitnami/kubectl:1.21.5
+          image: docker.io/bitnami/kubectl:1.21.5
           imagePullPolicy: IfNotPresent
           name: delete-deployment
           ports: []

--- a/tests/golden/openshift4/resource-locker/resource-locker/10_upgrade_job.yaml
+++ b/tests/golden/openshift4/resource-locker/resource-locker/10_upgrade_job.yaml
@@ -86,7 +86,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: NEW_VERSION
               value: v1.1.0
-          image: quay.io/bitnami/kubectl:1.21.5
+          image: docker.io/bitnami/kubectl:1.21.5
           imagePullPolicy: IfNotPresent
           name: delete-deployment
           ports: []


### PR DESCRIPTION
The bitnami images have disappeared on quay.io. According to https://blog.bitnami.com/2021/07/vmware-joins-docker-verified-publisher.html docker.io/bitnami should be exempt from the pull rate limits.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
