### PR TITLE
Add support for generating ServiceAccount token secrets

### DIFF
--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -162,6 +162,17 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
     metadata+: rbac_meta {
       namespace: namespace,
     },
+    secrets: [ { name: saname } ],
+  };
+  // Create service account token secret
+  local tokensecret = kube.Secret(saname) {
+    metadata+: rbac_meta {
+      namespace: namespace,
+      annotations+: {
+        'kubernetes.io/service-account.name': saname,
+      },
+    },
+    type: 'kubernetes.io/service-account-token',
   };
   // Create cluster role to get/list/watch resource kind
   local rolename = clusterRoleName(name);
@@ -204,6 +215,7 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
     serviceaccount: serviceaccount,
     objs: std.prune([
       serviceaccount,
+      tokensecret,
       clusterrole,
       clusterrolebinding,
       role,

--- a/tests/golden/lib/resource-locker/tests/test-lock.yaml
+++ b/tests/golden/lib/resource-locker/tests/test-lock.yaml
@@ -10,6 +10,23 @@ metadata:
     name: foo-test-6e4cb03e339fd56-manager
   name: foo-test-6e4cb03e339fd56-manager
   namespace: syn-resource-locker
+secrets:
+  - name: foo-test-6e4cb03e339fd56-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: foo-test-6e4cb03e339fd56-manager
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: apps.Deployment/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-6e4cb03e339fd56-manager
+  name: foo-test-6e4cb03e339fd56-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/tests/golden/lib/resource-locker/tests/test-patch-long-name.yaml
+++ b/tests/golden/lib/resource-locker/tests/test-patch-long-name.yaml
@@ -9,6 +9,22 @@ metadata:
     name: clusterrolebinding-system-build-775295b1777a143-manager
   name: clusterrolebinding-system-build-775295b1777a143-manager
   namespace: syn-resource-locker
+secrets:
+  - name: clusterrolebinding-system-build-775295b1777a143-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: clusterrolebinding-system-build-775295b1777a143-manager
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: clusterrolebinding-system-build-775295b1777a143-manager
+  name: clusterrolebinding-system-build-775295b1777a143-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/tests/golden/lib/resource-locker/tests/test-patch.yaml
+++ b/tests/golden/lib/resource-locker/tests/test-patch.yaml
@@ -10,6 +10,23 @@ metadata:
     name: foo-test-6e4cb03e339fd56-manager
   name: foo-test-6e4cb03e339fd56-manager
   namespace: syn-resource-locker
+secrets:
+  - name: foo-test-6e4cb03e339fd56-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: foo-test-6e4cb03e339fd56-manager
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: apps.Deployment/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-6e4cb03e339fd56-manager
+  name: foo-test-6e4cb03e339fd56-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
The resource-locker operator requires a ServiceAccount token secret for each manager ServiceAccount. To ensure those secrets exist on Kubernetes 1.24+, we explicitly create them in the component library for each manager ServiceAccount.

Additionally, we add the explicitly created secret to the corresponding ServiceAccount's `secrets` field, as resource-locker operator only considers secrets listed there when discovering token secrets.

Theoretically, this is not required for K8s <= 1.23, but creating the secrets anyway shouldn't break anything, so we unconditionally create them.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
