### PR TITLE
Fix generated RBAC rules for managing RBAC resources

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -12,6 +12,14 @@ The resource names are generated to be unique, even if multiple components try t
 Additionally, the component library adds labels and annotations containing human-readable information about the resource to patch and the component managing the patch.
 ====
 
+[NOTE]
+====
+The component library will grant a manager ServiceAccount `cluster-admin` permissions when the target resource is a `ClusterRoleBinding`.
+This is necessary, because Kubernetes doesn't allow principals to modify `ClusterRoleBindings` which are more privileged than the principal and we can't reliably identify any potential permissions that the ServiceAccount must have in order to be able to modify the managed `ClusterRoleBinding`.
+
+For the same reason, the library will grant a manager ServiceAccount `admin` permissions in the target resource's namespace if the resource is a `RoleBinding`.
+====
+
 A brief usage example which creates a configuration for the operator which enforces the presence of a resource quota object in namespace `default`:
 
 [source,jsonnet]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -14,10 +14,12 @@ Additionally, the component library adds labels and annotations containing human
 
 [NOTE]
 ====
-The component library will grant a manager ServiceAccount `cluster-admin` permissions when the target resource is a `ClusterRoleBinding`.
+The component library will grant a manager ServiceAccount `cluster-admin`-like permissions when the target resource is a `ClusterRoleBinding`.
 This is necessary, because Kubernetes doesn't allow principals to modify `ClusterRoleBindings` which are more privileged than the principal and we can't reliably identify any potential permissions that the ServiceAccount must have in order to be able to modify the managed `ClusterRoleBinding`.
 
-For the same reason, the library will grant a manager ServiceAccount `admin` permissions in the target resource's namespace if the resource is a `RoleBinding`.
+For the same reason, the library will grant a manager ServiceAccount `admin`-like permissions in the target resource's namespace if the resource is a `RoleBinding`.
+
+The component doesn't actually grant the ServiceAccount the `cluster-admin` or `admin` cluster roles, but instead creates a `ClusterRole` or `Role` with a single rule `{"apiGroups": ["\*"], "resources": ["*"], "verbs": ["*"]}`.
 ====
 
 A brief usage example which creates a configuration for the operator which enforces the presence of a resource quota object in namespace `default`:

--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -180,11 +180,8 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   local suffix = if std.endsWith(res, 's') then 'es' else 's';
   local resource = res + suffix;
   local clusterrole_extra_verbs = if dest_ns == null then verbs else [];
-  // if we want to manage a clusterrolebinding, we need to grant cluster
-  // admin, as we can't reliably identify the permissions we may be granting
-  // by editing a clusterrolebinding.
   local clusterrole =
-    if objdata.kind != 'ClusterRoleBinding' then
+    if !std.member([ 'ClusterRoleBinding', 'ClusterRole' ], objdata.kind) then
       kube.ClusterRole(rolename) {
         metadata+: rbac_meta,
         rules+: [ {
@@ -194,6 +191,11 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
         } ],
       }
     else
+      // If we're managing a ClusterRoleBinding or ClusterRole, grant
+      // cluster-admin permissions (modelled as { apiGroups: ['*'], resources:
+      // ['*'], verbs: ['*'] }).
+      // This is necessary because we can't reliably identify the permissions
+      // we may be granting by editing a clusterrolebinding.
       kube.ClusterRole(rolename) {
         metadata+: rbac_meta {
           annotations+: {
@@ -216,7 +218,7 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   };
   // Create role in destination namespace to allow managing the resource kind
   local role = if dest_ns != null then
-    if objdata.kind != 'RoleBinding' then
+    if !std.member([ 'RoleBinding', 'Role' ], objdata.kind) then
       kube.Role(rolename) {
         metadata+: rbac_meta {
           namespace: dest_ns,
@@ -228,6 +230,9 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
         } ],
       }
     else
+      // If we're managing a RoleBinding or Role, grant admin permissions
+      // (modelled as { apiGroups: ['*'], resources: ['*'], verbs: ['*'] }) in
+      // the namespace.
       kube.Role(rolename) {
         metadata+: rbac_meta {
           namespace: dest_ns,

--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -180,14 +180,35 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
   local suffix = if std.endsWith(res, 's') then 'es' else 's';
   local resource = res + suffix;
   local clusterrole_extra_verbs = if dest_ns == null then verbs else [];
-  local clusterrole = kube.ClusterRole(rolename) {
-    metadata+: rbac_meta,
-    rules+: [ {
-      apiGroups: [ objdata.apigroup ],
-      resources: [ resource ],
-      verbs: std.setUnion([ 'list', 'watch' ], clusterrole_extra_verbs),
-    } ],
-  };
+  // if we want to manage a clusterrolebinding, we need to grant cluster
+  // admin, as we can't reliably identify the permissions we may be granting
+  // by editing a clusterrolebinding.
+  local clusterrole =
+    if objdata.kind != 'ClusterRoleBinding' then
+      kube.ClusterRole(rolename) {
+        metadata+: rbac_meta,
+        rules+: [ {
+          apiGroups: [ objdata.apigroup ],
+          resources: [ resource ],
+          verbs: std.setUnion([ 'list', 'watch' ], clusterrole_extra_verbs),
+        } ],
+      }
+    else
+      kube.ClusterRole(rolename) {
+        metadata+: rbac_meta {
+          annotations+: {
+            'resourcelocker.syn.tools/cluster-admin':
+              'This resource-locker clusterrole grants cluster-admin ' +
+              "because it's otherwise impossible to manage clusterrolebindings " +
+              'with unknown role references',
+          },
+        },
+        rules: [ {
+          apiGroups: [ '*' ],
+          resources: [ '*' ],
+          verbs: [ '*' ],
+        } ],
+      };
   local clusterrolebinding = kube.ClusterRoleBinding(rolename) {
     metadata+: rbac_meta,
     subjects_: [ serviceaccount ],

--- a/lib/resource-locker.libjsonnet
+++ b/lib/resource-locker.libjsonnet
@@ -215,16 +215,35 @@ local rbac_objs(objdata, verbs=[ 'create', 'get', 'update', 'patch' ]) =
     roleRef_: clusterrole,
   };
   // Create role in destination namespace to allow managing the resource kind
-  local role = if dest_ns != null then kube.Role(rolename) {
-    metadata+: rbac_meta {
-      namespace: dest_ns,
-    },
-    rules+: [ {
-      apiGroups: [ objdata.apigroup ],
-      resources: [ resource ],
-      verbs: verbs,
-    } ],
-  };
+  local role = if dest_ns != null then
+    if objdata.kind != 'RoleBinding' then
+      kube.Role(rolename) {
+        metadata+: rbac_meta {
+          namespace: dest_ns,
+        },
+        rules+: [ {
+          apiGroups: [ objdata.apigroup ],
+          resources: [ resource ],
+          verbs: verbs,
+        } ],
+      }
+    else
+      kube.Role(rolename) {
+        metadata+: rbac_meta {
+          namespace: dest_ns,
+          annotations+: {
+            'resourcelocker.syn.tools/cluster-admin':
+              'This resource-locker role grants admin ' +
+              "because it's otherwise impossible to manage rolebindings " +
+              'with unknown role references',
+          },
+        },
+        rules+: [ {
+          apiGroups: [ '*' ],
+          resources: [ '*' ],
+          verbs: [ '*' ],
+        } ],
+      };
   local rolebinding = if dest_ns != null then kube.RoleBinding(rolename) {
     metadata+: rbac_meta {
       namespace: dest_ns,

--- a/tests/golden/lib/resource-locker/tests/clusterrolebindingpatch.yaml
+++ b/tests/golden/lib/resource-locker/tests/clusterrolebindingpatch.yaml
@@ -3,28 +3,28 @@ kind: ServiceAccount
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-950d7de603ea050-manager
-  name: foo-test-950d7de603ea050-manager
+    name: foo-test-8c80c57012dfcac-manager
+  name: foo-test-8c80c57012dfcac-manager
   namespace: syn-resource-locker
 secrets:
-  - name: foo-test-950d7de603ea050-manager
+  - name: foo-test-8c80c57012dfcac-manager
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    kubernetes.io/service-account.name: foo-test-950d7de603ea050-manager
+    kubernetes.io/service-account.name: foo-test-8c80c57012dfcac-manager
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-950d7de603ea050-manager
-  name: foo-test-950d7de603ea050-manager
+    name: foo-test-8c80c57012dfcac-manager
+  name: foo-test-8c80c57012dfcac-manager
   namespace: syn-resource-locker
 type: kubernetes.io/service-account-token
 ---
@@ -36,12 +36,12 @@ metadata:
       cluster-admin because it's otherwise impossible to manage clusterrolebindings
       with unknown role references
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
 rules:
   - apiGroups:
       - '*'
@@ -55,19 +55,19 @@ kind: ClusterRoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-8c80c57012dfcac-manager
     namespace: syn-resource-locker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -75,18 +75,18 @@ kind: Role
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
   namespace: foo
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - clusterroles
+      - clusterrolebindings
     verbs:
       - get
       - patch
@@ -96,20 +96,20 @@ kind: RoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
   namespace: foo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-8c80c57012dfcac-manager
     namespace: syn-resource-locker
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -118,8 +118,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
-    name: foo-test-950d7de603ea050
-  name: foo-test-950d7de603ea050
+    name: foo-test-8c80c57012dfcac
+  name: foo-test-8c80c57012dfcac
   namespace: syn-resource-locker
 spec:
   patches:
@@ -128,8 +128,8 @@ spec:
       patchType: application/strategic-merge-patch+json
       targetObjectRef:
         apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
+        kind: ClusterRoleBinding
         name: test
         namespace: foo
   serviceAccountRef:
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-8c80c57012dfcac-manager

--- a/tests/golden/lib/resource-locker/tests/clusterrolepatch.yaml
+++ b/tests/golden/lib/resource-locker/tests/clusterrolepatch.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-8c80c57012dfcac-manager
+  name: foo-test-8c80c57012dfcac-manager
+  namespace: syn-resource-locker
+secrets:
+  - name: foo-test-8c80c57012dfcac-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: foo-test-8c80c57012dfcac-manager
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-8c80c57012dfcac-manager
+  name: foo-test-8c80c57012dfcac-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    resourcelocker.syn.tools/cluster-admin: This resource-locker clusterrole grants
+      cluster-admin because it's otherwise impossible to manage clusterrolebindings
+      with unknown role references
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+subjects:
+  - kind: ServiceAccount
+    name: foo-test-8c80c57012dfcac-manager
+    namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  namespace: foo
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+  namespace: foo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-resource-locker-foo-test-8c80c57012dfcac-manager
+subjects:
+  - kind: ServiceAccount
+    name: foo-test-8c80c57012dfcac-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: foo-test-8c80c57012dfcac
+  name: foo-test-8c80c57012dfcac
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"metadata\":\n  \"annotations\":\n    \"patched\": \"\""
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: test
+        namespace: foo
+  serviceAccountRef:
+    name: foo-test-8c80c57012dfcac-manager

--- a/tests/golden/lib/resource-locker/tests/rolebindingpatch.yaml
+++ b/tests/golden/lib/resource-locker/tests/rolebindingpatch.yaml
@@ -3,28 +3,28 @@ kind: ServiceAccount
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-950d7de603ea050-manager
-  name: foo-test-950d7de603ea050-manager
+    name: foo-test-f1f84951181bec9-manager
+  name: foo-test-f1f84951181bec9-manager
   namespace: syn-resource-locker
 secrets:
-  - name: foo-test-950d7de603ea050-manager
+  - name: foo-test-f1f84951181bec9-manager
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    kubernetes.io/service-account.name: foo-test-950d7de603ea050-manager
+    kubernetes.io/service-account.name: foo-test-f1f84951181bec9-manager
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-950d7de603ea050-manager
-  name: foo-test-950d7de603ea050-manager
+    name: foo-test-f1f84951181bec9-manager
+  name: foo-test-f1f84951181bec9-manager
   namespace: syn-resource-locker
 type: kubernetes.io/service-account-token
 ---
@@ -32,84 +32,83 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    resourcelocker.syn.tools/cluster-admin: This resource-locker clusterrole grants
-      cluster-admin because it's otherwise impossible to manage clusterrolebindings
-      with unknown role references
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
 rules:
   - apiGroups:
-      - '*'
+      - rbac.authorization.k8s.io
     resources:
-      - '*'
+      - rolebindings
     verbs:
-      - '*'
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-f1f84951181bec9-manager
     namespace: syn-resource-locker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   annotations:
+    resourcelocker.syn.tools/cluster-admin: This resource-locker role grants admin
+      because it's otherwise impossible to manage rolebindings with unknown role references
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
   namespace: foo
 rules:
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - '*'
     resources:
-      - clusterroles
+      - '*'
     verbs:
-      - get
-      - patch
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRole/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-950d7de603ea050-manager
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
   namespace: foo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: syn-resource-locker-foo-test-950d7de603ea050-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-f1f84951181bec9-manager
     namespace: syn-resource-locker
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -118,8 +117,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
-    name: foo-test-950d7de603ea050
-  name: foo-test-950d7de603ea050
+    name: foo-test-f1f84951181bec9
+  name: foo-test-f1f84951181bec9
   namespace: syn-resource-locker
 spec:
   patches:
@@ -128,8 +127,8 @@ spec:
       patchType: application/strategic-merge-patch+json
       targetObjectRef:
         apiVersion: rbac.authorization.k8s.io/v1
-        kind: ClusterRole
+        kind: RoleBinding
         name: test
         namespace: foo
   serviceAccountRef:
-    name: foo-test-950d7de603ea050-manager
+    name: foo-test-f1f84951181bec9-manager

--- a/tests/golden/lib/resource-locker/tests/rolepatch.yaml
+++ b/tests/golden/lib/resource-locker/tests/rolepatch.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-f1f84951181bec9-manager
+  name: foo-test-f1f84951181bec9-manager
+  namespace: syn-resource-locker
+secrets:
+  - name: foo-test-f1f84951181bec9-manager
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: foo-test-f1f84951181bec9-manager
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: foo-test-f1f84951181bec9-manager
+  name: foo-test-f1f84951181bec9-manager
+  namespace: syn-resource-locker
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+subjects:
+  - kind: ServiceAccount
+    name: foo-test-f1f84951181bec9-manager
+    namespace: syn-resource-locker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    resourcelocker.syn.tools/cluster-admin: This resource-locker role grants admin
+      because it's otherwise impossible to manage rolebindings with unknown role references
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  namespace: foo
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    resourcelocker.syn.tools/target-namespace: foo
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: resource-locker
+    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  namespace: foo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+subjects:
+  - kind: ServiceAccount
+    name: foo-test-f1f84951181bec9-manager
+    namespace: syn-resource-locker
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: foo-test-f1f84951181bec9
+  name: foo-test-f1f84951181bec9
+  namespace: syn-resource-locker
+spec:
+  patches:
+    - id: patch1
+      patchTemplate: "\"metadata\":\n  \"annotations\":\n    \"patched\": \"\""
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: test
+        namespace: foo
+  serviceAccountRef:
+    name: foo-test-f1f84951181bec9-manager

--- a/tests/golden/lib/resource-locker/tests/rolepatch.yaml
+++ b/tests/golden/lib/resource-locker/tests/rolepatch.yaml
@@ -3,28 +3,28 @@ kind: ServiceAccount
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-f1f84951181bec9-manager
-  name: foo-test-f1f84951181bec9-manager
+    name: foo-test-d32555f73d8a5a0-manager
+  name: foo-test-d32555f73d8a5a0-manager
   namespace: syn-resource-locker
 secrets:
-  - name: foo-test-f1f84951181bec9-manager
+  - name: foo-test-d32555f73d8a5a0-manager
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    kubernetes.io/service-account.name: foo-test-f1f84951181bec9-manager
+    kubernetes.io/service-account.name: foo-test-d32555f73d8a5a0-manager
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: foo-test-f1f84951181bec9-manager
-  name: foo-test-f1f84951181bec9-manager
+    name: foo-test-d32555f73d8a5a0-manager
+  name: foo-test-d32555f73d8a5a0-manager
   namespace: syn-resource-locker
 type: kubernetes.io/service-account-token
 ---
@@ -33,17 +33,17 @@ kind: ClusterRole
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+    name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
 rules:
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - rolebindings
+      - roles
     verbs:
       - list
       - watch
@@ -53,19 +53,19 @@ kind: ClusterRoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+    name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-f1f84951181bec9-manager
+    name: foo-test-d32555f73d8a5a0-manager
     namespace: syn-resource-locker
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -75,12 +75,12 @@ metadata:
     resourcelocker.syn.tools/cluster-admin: This resource-locker role grants admin
       because it's otherwise impossible to manage rolebindings with unknown role references
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+    name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
   namespace: foo
 rules:
   - apiGroups:
@@ -95,20 +95,20 @@ kind: RoleBinding
 metadata:
   annotations:
     resourcelocker.syn.tools/target-namespace: foo
-    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.RoleBinding/test
+    resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.Role/test
   labels:
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/part-of: resource-locker
-    name: syn-resource-locker-foo-test-f1f84951181bec9-manager
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+    name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
   namespace: foo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: syn-resource-locker-foo-test-f1f84951181bec9-manager
+  name: syn-resource-locker-foo-test-d32555f73d8a5a0-manager
 subjects:
   - kind: ServiceAccount
-    name: foo-test-f1f84951181bec9-manager
+    name: foo-test-d32555f73d8a5a0-manager
     namespace: syn-resource-locker
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
@@ -117,8 +117,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
-    name: foo-test-f1f84951181bec9
-  name: foo-test-f1f84951181bec9
+    name: foo-test-d32555f73d8a5a0
+  name: foo-test-d32555f73d8a5a0
   namespace: syn-resource-locker
 spec:
   patches:
@@ -127,8 +127,8 @@ spec:
       patchType: application/strategic-merge-patch+json
       targetObjectRef:
         apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
+        kind: Role
         name: test
         namespace: foo
   serviceAccountRef:
-    name: foo-test-f1f84951181bec9-manager
+    name: foo-test-d32555f73d8a5a0-manager

--- a/tests/golden/lib/resource-locker/tests/test-patch-long-name.yaml
+++ b/tests/golden/lib/resource-locker/tests/test-patch-long-name.yaml
@@ -30,6 +30,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    resourcelocker.syn.tools/cluster-admin: This resource-locker clusterrole grants
+      cluster-admin because it's otherwise impossible to manage clusterrolebindings
+      with unknown role references
     resourcelocker.syn.tools/target-object: rbac.authorization.k8s.io.ClusterRoleBinding/system:build-strategy-docker-binding
   labels:
     app.kubernetes.io/managed-by: commodore
@@ -38,14 +41,11 @@ metadata:
   name: syn-resource-locker-inding-system-build-775295b1777a143-manager
 rules:
   - apiGroups:
-      - rbac.authorization.k8s.io
+      - '*'
     resources:
-      - clusterrolebindings
+      - '*'
     verbs:
-      - get
-      - list
-      - patch
-      - watch
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/lib.yml
+++ b/tests/lib.yml
@@ -15,3 +15,7 @@ parameters:
         input_paths:
           - tests/test-patch-long-name.jsonnet
         output_path: tests/
+      - input_type: jsonnet
+        input_paths:
+          - tests/test-patch-admin.jsonnet
+        output_path: tests/

--- a/tests/test-patch-admin.jsonnet
+++ b/tests/test-patch-admin.jsonnet
@@ -4,7 +4,7 @@ local rl = import 'lib/resource-locker.libjsonnet';
 
 {
   rolepatch: rl.Patch(
-    kube.RoleBinding('test') {
+    kube.Role('test') {
       metadata+: {
         namespace: 'foo',
       },
@@ -18,6 +18,34 @@ local rl = import 'lib/resource-locker.libjsonnet';
     },
   ),
   clusterrolepatch: rl.Patch(
+    kube.ClusterRole('test') {
+      metadata+: {
+        namespace: 'foo',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          patched: '',
+        },
+      },
+    },
+  ),
+  rolebindingpatch: rl.Patch(
+    kube.RoleBinding('test') {
+      metadata+: {
+        namespace: 'foo',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          patched: '',
+        },
+      },
+    },
+  ),
+  clusterrolebindingpatch: rl.Patch(
     kube.ClusterRoleBinding('test') {
       metadata+: {
         namespace: 'foo',

--- a/tests/test-patch-admin.jsonnet
+++ b/tests/test-patch-admin.jsonnet
@@ -1,0 +1,34 @@
+local kube = import 'lib/kube.libjsonnet';
+local rl = import 'lib/resource-locker.libjsonnet';
+
+
+{
+  rolepatch: rl.Patch(
+    kube.RoleBinding('test') {
+      metadata+: {
+        namespace: 'foo',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          patched: '',
+        },
+      },
+    },
+  ),
+  clusterrolepatch: rl.Patch(
+    kube.ClusterRoleBinding('test') {
+      metadata+: {
+        namespace: 'foo',
+      },
+    },
+    {
+      metadata: {
+        annotations: {
+          patched: '',
+        },
+      },
+    },
+  ),
+}


### PR DESCRIPTION
We need to grant the manager ServiceAccount `cluster-admin` if the target resource is a `ClusterRoleBinding` or `ClusterRole`, and `admin` in the target namespace if the target resource is a `RoleBinding` or `Role`. This is necessary because Kubernetes doesn't allow principals to modify (Cluster)Roles and (Cluster)RoleBindings which grant more permissions than what the principal has itself. By granting manager ServiceAccounts which manage RBAC resources admin permissions in the relevant scope, we ensure that those patches can be applied by resource-locker-operator.

Please note that we're not granting the actual `cluster-admin` / `admin` roles, but instead create a `ClusterRole` or `Role` with the single rule `{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
